### PR TITLE
Enabled Develocity build caching

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/pom.xml
+++ b/pom.xml
@@ -1314,6 +1314,31 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>develocity-maven-extension</artifactId>
+          <configuration>
+            <develocity>
+              <normalization>
+                <runtimeClassPath>
+                  <propertiesNormalizations>
+                    <propertiesNormalization>
+                      <path>**/build.properties</path>
+                      <ignoredProperties>
+                        <ignore>timestamp</ignore>
+                      </ignoredProperties>
+                    </propertiesNormalization>
+                  </propertiesNormalizations>
+                </runtimeClassPath>
+                <systemProperties>
+                  <ignoredKeys>
+                    <ignore>mavenRepoPath</ignore>
+                  </ignoredKeys>
+                </systemProperties>
+              </normalization>
+            </develocity>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>${license.maven.plugin.version}</version>


### PR DESCRIPTION
This PR enables [Develocity build caching](https://docs.gradle.com/develocity/maven-build-cache/), which will improve both local and CI build times and can work in tandem with the Maven build caching extension. 

You can see it in action (while working with Maven Build cache) here: When `running  mvn clean verify -Dmaven.build.cache.enabled=true -pl jetty-core/jetty-util` without Develocity caching the build takes [1m 20s](https://ge.solutions-team.gradle.com/s/5jvelckzhvhhy), but when Develocity caching is enabled, that can be brought down to only [7s](https://ge.solutions-team.gradle.com/s/j7wzgdtsiyhtq).

This PR relates to issue https://github.com/jetty/jetty.project/issues/12784 and includes the changes from PR https://github.com/jetty/jetty.project/pull/12785.